### PR TITLE
Update tox matrix to include Wagtail 6.3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 min_version = 4.11
 
 env_list =
-    python{39,310,311}-django4.2-wagtail{5.2,6.1,6.2}
-    python{310,311,312}-django5.0-wagtail{5.2,6.1,6.2}
-    python312-django5.1-wagtail{6.2,main}
+    python{39,310,311}-django4.2-wagtail{5.2,6.1,6.2,6.3}
+    python{310,311,312}-django5.0-wagtail{5.2,6.1,6.2,6.3}
+    python312-django5.1-wagtail{6.3,main}
 
 [gh-actions]
 python =
@@ -40,6 +40,7 @@ deps =
     wagtail5.2: wagtail>=5.2,<5.3
     wagtail6.1: wagtail>=6.1,<6.2
     wagtail6.2: wagtail>=6.2,<6.3
+    wagtail6.3: wagtail>=6.3,<6.4
 
 install_command = python -Im pip install -U {opts} {packages}
 


### PR DESCRIPTION
This pull request updates the `tox.ini` file to include support for Wagtail 6.3. The most important changes are:

* Updated the `env_list` to include Wagtail 6.3 for the relevant Python and Django versions.
* Added the dependency specification for Wagtail 6.3 in the `deps` section.