### PR TITLE
Wagtail 7.0 maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Now you can run tests as shown below:
 tox
 ```
 
-or, you can run them for a specific environment `tox -e python3.12-django4.2-wagtail5.2` or specific test
-`tox -e python3.12-django4.2-wagtail5.2 -- tests.test_file.TestClass.test_method`
+or, you can run them for a specific environment `tox -e python3.9-django4.2-wagtail6.3` or specific test
+`tox -e python3.9-django4.2-wagtail6.3 -- tests.test_file.TestClass.test_method`
 
 To run the test app interactively, use `tox -e interactive`, visit `http://127.0.0.1:8020/admin/` and log in with `admin`/`changeme`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,10 @@ classifiers = [
     "Framework :: Django",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",
+    "Framework :: Wagtail :: 7",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
@@ -29,7 +30,7 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
-    "Wagtail>=5.2",
+    "Wagtail>=6.3",
     "python-dateutil>=2.8,<3.0.0"
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 min_version = 4.11
 
 env_list =
-    python{39,310,311}-django4.2-wagtail{5.2,6.3,6.4}
-    python{312,313}-django5.1-wagtail{6.3,6.4,main}
+    python{39}-django4.2-wagtail{6.3,6.4,7.0}
+    python{310,311,312,313}-django{5.1,5.2}-wagtail{6.3,6.4,7.0,main}
 
 [gh-actions]
 python =
@@ -36,10 +36,11 @@ deps =
 
     django4.2: Django>=4.2,<4.3
     django5.1: Django>=5.1,<5.2
+    django5.2: Django>=5.2,<5.3
 
-    wagtail5.2: wagtail>=5.2,<5.3
     wagtail6.3: wagtail>=6.3,<6.4
     wagtail6.4: wagtail>=6.4,<6.5
+    wagtail7.0: wagtail>=7.0,<7.1
 
 install_command = python -Im pip install -U {opts} {packages}
 
@@ -64,7 +65,7 @@ base_python = python3.13
 package = editable
 
 deps =
-    wagtail>=5.2
+    wagtail>=6.3
 
 commands_pre =
     python {toxinidir}/tests/manage.py makemigrations


### PR DESCRIPTION
This pull request updates the project to support newer versions of Django and Wagtail while removing support for older versions. 

### Updates to Django and Wagtail support:
* Added support for Django 5.2 and Wagtail 7.0 in the `classifiers` section of `pyproject.toml`. 
* Removed references to Wagtail 5.
* Minimum required Wagtail version is now `6.3` in `pyproject.toml`.

### Testing configuration updates:
* Adjusted `tox.ini` to include Django 5.2 and Wagtail 7.0 in the test matrix
* removes configurations for Wagtail 5.2.
* Added Django 5.2 and Wagtail 7.0 in `tox.ini`.
* default Wagtail version is now `6.3` for testing.

### Documentation updates:
* Updated `README.md` to reflect the new default test environment (`python3.9-django4.2-wagtail6.3`) for running tests.