### PR TITLE
Update for Wagtail 7.1 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Added Support for Wagtail 7.1 (@damwaingames)
+
 ## [0.4.0] - 2024-08-22
 
 ### Added

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 min_version = 4.11
 
 env_list =
-    python{39}-django4.2-wagtail{6.3,6.4,7.0}
-    python{310,311,312,313}-django{5.1,5.2}-wagtail{6.3,6.4,7.0,main}
+    python{39}-django4.2-wagtail{6.3,7.0,7.1}
+    python{310,311,312,313}-django{5.1,5.2}-wagtail{6.3,7.0,7.1,main}
 
 [gh-actions]
 python =
@@ -39,8 +39,8 @@ deps =
     django5.2: Django>=5.2,<5.3
 
     wagtail6.3: wagtail>=6.3,<6.4
-    wagtail6.4: wagtail>=6.4,<6.5
     wagtail7.0: wagtail>=7.0,<7.1
+    wagtail7.1: wagtail>=7.1,<7.2
 
 install_command = python -Im pip install -U {opts} {packages}
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,9 @@
 min_version = 4.11
 
 env_list =
-    python{39}-django4.2-wagtail{6.3,7.0,7.1}
-    python{310,311,312,313}-django{5.1,5.2}-wagtail{6.3,7.0,7.1,main}
+    python{39}-django{4.2}-wagtail{6.3,7.0}
+    python{310,311,312}-django{5.1}-wagtail{7.0,7.1}
+    python{313}-django{5.2}-wagtail{7.1,main}
 
 [gh-actions]
 python =


### PR DESCRIPTION
Update to support Wagtail 7.1 only needed changes to the tox testing matrix.

### Updates to testing
- tox.ini
    - Added Wagtail 7.1 to the test matrixes, removed 6.4 (EOL)

### Documentation update
- Updated CHANGELOG